### PR TITLE
encodeURIComponent to escape URL param

### DIFF
--- a/spritz.js
+++ b/spritz.js
@@ -220,7 +220,7 @@ function getSelectionText() {
 function spritzifyURL(){
     var url = document.URL;
 
-    $.getJSON("https://www.readability.com/api/content/v1/parser?url="+ url +"&token=" + readability_token +"&callback=?",
+    $.getJSON("https://www.readability.com/api/content/v1/parser?url="+ encodeURIComponent(url) +"&token=" + readability_token +"&callback=?",
     function (data) {
 
         if(data.error){


### PR DESCRIPTION
Didn't work for me without escaping the URL... (Chrome, Mac) 
I tested it with my own Readability Key (not part of the pull request)

Cool project!
