### PR TITLE
Increased the minimum version from 1.11. to 1.7.

### DIFF
--- a/spritz.js
+++ b/spritz.js
@@ -28,7 +28,7 @@ function create_spritz(){
 function load_jq(spritz_loader){
 
     // the minimum version of jQuery we want
-    var v = "1.11.0";
+    var v = "1.7.0";
 
     // check prior inclusion and version
     if (window.jQuery === undefined || window.jQuery.fn.jquery < v) {


### PR DESCRIPTION
`jQuery.on` is used on the [spritz.html](https://github.com/Miserlou/OpenSpritz/blob/5ed8908df0919175532ed2095d616abc69e7b5fd/spritz.html#L55) file. This jQuery functionality was added with version 1.7.

Therefore the minimum jquery version of 1.11. as stated in [spritz.js](https://github.com/Miserlou/OpenSpritz/blob/0f18e46ab11f46e6f6a9010d1211f57801c57d9c/spritz.js#L31) is wrong.
