### PR TITLE
Progress guides

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,8 @@
             <div class='button'>
                 <a href="javascript:(function(){ cb = function(){ create_spritz(); }; var script=document.createElement('SCRIPT');script.src='https://miserlou.github.io/OpenSpritz/spritz.js?callback=cb'; script.onload=cb; document.body.appendChild(script);})();">
 
-                <!--<a href="javascript:(function(){ cb = function(){ create_spritz(); }; var script=document.createElement('SCRIPT');script.src='/spritz.js?callback=cb'; script.onload=cb; document.body.appendChild(script);})();">-->
+                <!--
+                <a href="javascript:(function(){ cb = function(){ create_spritz(); }; var script=document.createElement('SCRIPT');script.src='/spritz.js?callback=cb'; script.onload=cb; document.body.appendChild(script);})();">-->
                     OpenSpritz this!
                 <a />
             </div>

--- a/spritz.html
+++ b/spritz.html
@@ -1,21 +1,18 @@
 <div>
 <link href='https://fonts.googleapis.com/css?family=Droid+Sans+Mono' rel='stylesheet' type='text/css'>
-<link href='https://rawgithub.com/Miserlou/OpenSpritz/master/style.css' rel='stylesheet' type='text/css'>        
+<link href='https://rawgithub.com/Miserlou/OpenSpritz/master/style.css' rel='stylesheet' type='text/css'>
+<!--<link href='/style.css' rel='stylesheet' type='text/css'>-->
 
 <div id="spritz_holder">
         <div id="spritz_container">
 
-            <div id="guide_top">
-――――――――――<span id="notch">&#1092;</span>―――――――――――
+            <div id="spritz_progress_wrapper">
+              <div style="width:100%" id="spritz_progress_bar"></div>
             </div>
-
             <div id="spritz_result">
                 Choose a WPM to start.
             </div>
-
-            <div id="guide_bottom">
-――――――――――――――――――――――
-            </div>
+            
 
             <select id="spritz_selector">
               <option value="0">Select WPM</option>

--- a/spritz.js
+++ b/spritz.js
@@ -131,6 +131,9 @@ function spritzify(input){
     });
 
     function updateValues(i) {
+        var progressBar = document.getElementById("spritz_progress_bar");
+
+        progressBar.style.width = (100 - ((i / progressBar.max) * 100)) + "%";
         document.getElementById("spritz_slider").value = i;
         var p = pivot(all_words[i]);
 
@@ -145,6 +148,8 @@ function spritzify(input){
         running = true;
         // Set slider max value
         document.getElementById("spritz_slider").max = all_words.length;
+        document.getElementById("spritz_progress_bar").max = all_words.length;
+
 
         spritz_timers.push(setInterval(function() {
             updateValues(currentWord);

--- a/style.css
+++ b/style.css
@@ -34,23 +34,21 @@ body{
     text-align: center;
     font-size: 32px;
     font-family: 'Droid Sans Mono', sans-serif;
-    padding-top: 9px;
-    padding-bottom: 9px;
     min-height: 40px;
+    padding: 20px 0;
+
+    border-top: 4px solid #DDDDDD;
+    border-bottom: 4px solid #DDDDDD;
 }
 
-#guide_top{
+#spritz_progress_wrapper {
     text-align: center;
-    font-size: 32px;
-    font-family: 'Droid Sans Mono', sans-serif;
-    color: #DDDDDD;
 }
 
-#guide_bottom{
-    text-align: center;
-    font-size: 32px;
-    font-family: 'Droid Sans Mono', sans-serif;
-    color: #DDDDDD;
+#spritz_progress_bar {
+    margin: auto;
+    margin-top: 20px;
+    border-bottom: 1px solid blue;
 }
 
 #notch{


### PR DESCRIPTION
Removing the silly text based guides, using borders instead (admittedly this doesn't have the ascii notch anymore either. 

Adding a slight progress bar on the top that gets smaller as you get closer to the end.

Tied in with the progress slider, it could be pretty neat and a non-distracting way to read.

![screen shot 2014-03-06 at 6 11 03 pm](https://f.cloud.github.com/assets/249164/2342741/1f14e486-a4ff-11e3-97cf-184ff269ab14.png)
