### PR TITLE
Remove public Readability API token

### DIFF
--- a/spritz.js
+++ b/spritz.js
@@ -8,9 +8,7 @@ function create_spritz(){
 
      spritz_loader = function() {
 
-        //$.get("https://rawgithub.com/Miserlou/OpenSpritz/master/spritz.html", function(data){
-        $.get("https://rawgithub.com/philipforget/OpenSpritz/master/spritz.html", function(data){
-
+        $.get("https://rawgithub.com/Miserlou/OpenSpritz/master/spritz.html", function(data){
             if (!($("#spritz_container").length) ) {
                 $("body").prepend(data);
             }


### PR DESCRIPTION
Proxy the requests with per-ip throttling and caching based on the code that lives here:

https://github.com/philipforget/rdb-app-engine-proxy
