### PR TITLE
Escape key closes the panel

### DIFF
--- a/spritz.html
+++ b/spritz.html
@@ -1,7 +1,7 @@
 <link href='https://fonts.googleapis.com/css?family=Droid+Sans+Mono' rel='stylesheet' type='text/css'>
 <link href='https://rawgithub.com/Miserlou/OpenSpritz/master/style.css' rel='stylesheet' type='text/css'>        
 
-<div id="spritz_holder">
+<div id="spritz_holder" tabindex="1">
         <div id="spritz_container">
 
             <div id="guide_top">

--- a/spritz.js
+++ b/spritz.js
@@ -29,6 +29,8 @@ function create_spritz(){
                 document.getElementById("spritz_toggle").style.display = "none";
             };
 
+            document.getElementById("spritz_holder").addEventListener("keydown", keys_spritz);
+            document.getElementById("spritz_holder").focus();
             document.getElementById("spritz_selector").addEventListener("change", function(e) {
                 clearTimeouts();
                 spritz();
@@ -50,6 +52,15 @@ function getURL(url, callback) {
 
     xmlhttp.open("GET", url, true);
     xmlhttp.send();
+}
+
+// Handles event keys for closing when pressing ESC
+function keys_spritz(event){
+    var key = event.keyCode || event.which;
+    // Hide it when Ecape key is pressed
+    if (key == 27){
+        hide_spritz();
+    }
 }
 
 function hide_spritz(){

--- a/style.css
+++ b/style.css
@@ -14,6 +14,7 @@ body{
     top: 0;
     left: 0;
     z-index: 99999999999999999;
+    outline: none;
 }
 
 #spritz_spacer{


### PR DESCRIPTION
Pressing Escape key closes the panel (#81). It should work in all modern browsers.
