### PR TITLE
rawgithub link forwards through to rawgit

### DIFF
--- a/spritz.js
+++ b/spritz.js
@@ -18,7 +18,11 @@ function create_spritz(){
         //getURL("spritz.html", function(data){
 
         //getURL("https://rawgithub.com/Miserlou/OpenSpritz/dev/spritz.html", function(data){
-        getURL("https://rawgit.com/Miserlou/OpenSpritz/master/spritz.html", function(data){
+
+        // RawGit's CDN usage:
+        // "Since files are not refreshed after the first request,
+        // it's best to use a specific tag or commit URL, not a branch URL."
+        getURL("https://cdn.rawgit.com/Miserlou/OpenSpritz/9e92c605032be16c986ed699d68e0acd3534e6b1/spritz.html", function(data){
             var spritzContainer = document.getElementById("spritz_container");
 
             if (!spritzContainer) {


### PR DESCRIPTION
Now, we skip the redirect, and we seem to get the correct headers back. Should fix everything: #106
