### PR TITLE
Prevent long words with dashes to appear on two lines. 

### DIFF
--- a/style.css
+++ b/style.css
@@ -41,6 +41,7 @@ body{
     padding-bottom: 9px;
     min-height: 40px;
     font-size: 32px;
+    white-space: nowrap;
 }
 
 #guide_top, #guide_bottom{


### PR DESCRIPTION
Long word with dashes appear on two lines. For example "Non-English-speaking".
